### PR TITLE
Migrate to Vivado 2020.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A sample design of the reference kit for FPGA Design Competition about autonomou
 ![ad-refkit](./docs/sec1/ad-refkit-image_s.jpg "ad-refkit")
 
 # Setup
-See [Docucments](./docs/README.md).
+See [documentations](./docs/README.md).
 
 # Reference
 - Yuya Kudo (Ritsumeikan U.), Atsushi Takada (Ritsumeikan U.), Yuta Ishida (Ritsumeikan U.), and Tomonori Izumi (Ritsumeikan U.), "An SoC-FPGA-Based Micro UGV with Localization and Motion Planning", Proc. 2019 International Conference on Field-Programmable Technology, pp.469-472, DOI 10.1109/ICFPT47387.2019.00095, Dec.2019.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 1. [Refkit Body](./sec1/index.md)
 1. [Building Hardware Design](./sec2/index.md)
-1. [Building Linux](./sec3/index.md) ...It is able to skip this step.
+1. [Building Linux](./sec3/index.md) optional, prebuilt files are available.
 1. [Prepare microSD](./sec4/index.md)
 1. [Run Application](./sec5/index.md)
 

--- a/docs/sec2/index.md
+++ b/docs/sec2/index.md
@@ -5,7 +5,7 @@ This flow generates a sample IP-block, bit-stream for ZYBO Z7-20, and BSP for th
 - Host PC, installed Ubuntu 18.04
 - Vivado 2019.1
 - [Digilent board files](https://github.com/Digilent/vivado-boards)
-- A license for MIPI CSI controller from [MIPI CSI Controller Subsystems](https://www.xilinx.com/products/intellectual-property/ef-di-mipi-csi-rx.html)
+- A license for MIPI CSI controller from [MIPI CSI Controller Subsystems](https://www.xilinx.com/products/intellectual-property/ef-di-mipi-csi-rx.html) This license is already included in your Vivado license if you obtained your Webpack license from January 2020, the following step might be required if you have the older Webpack license:
   - Access to [Product Licensing](http://www.xilinx.com/getlicense)
   - Click "Search Now"
   - Type "MIPI CSI" in "Search:" text field
@@ -14,7 +14,7 @@ This flow generates a sample IP-block, bit-stream for ZYBO Z7-20, and BSP for th
   - Fill required license and you can get an evaluation license of MIPI CSI controller.
 
 ## Building Flow
-Run the script to generate hardware design.
+Run the following script to generate hardware design. Make sure Vivado is in your path by sourcing the `settings64.sh` in Vivado's directory. 
 
 ``` sh
 $ cd <ROOT OF THIS REPOSITORY>/zybo/vivado/script
@@ -23,7 +23,7 @@ $ sh setup_bd.sh
 ```
 
 The script starts Vivado HLS and Vivado to generate IP-block and bit-file. The working directory is `$AD_REFKIT_SAMPLE_SCRIPT_PATH/../prj` .
-After running Vivado, the script generates `fpga.bin` in `<ROOT OF THIS REPOSITORY>/ROOT_FS/firmware`, which is a configuration file for dynamic reconfiguration of ZYBO Z7-20.
+After running Vivado, the script generates `fpga.bin` in `<ROOT OF THIS REPOSITORY>/ROOT_FS/firmware`, which is a configuration file for dynamic reconfiguration of ZYBO Z7-20. Please follow the board manual on how to program the FPGA using the generated bit file.
 The script also generates BSP for software development in `<ROOT OF THIS REPOSITORY>/zybo/ROOT_FS/zynq_bsp/`.
 
 ## Building Flow with Vivado 2020.1

--- a/docs/sec2/index.md
+++ b/docs/sec2/index.md
@@ -2,10 +2,10 @@
 This flow generates a sample IP-block, bit-stream for ZYBO Z7-20, and BSP for the generated HW.
 
 ## Requirements
-- Host PC, with Ubuntu 18.04
+- Host PC, installed Ubuntu 18.04
 - Vivado 2019.1
 - [Digilent board files](https://github.com/Digilent/vivado-boards)
-- A license for MIPI CSI controller from [MIPI CSI Controller Subsystems](https://www.xilinx.com/products/intellectual-property/ef-di-mipi-csi-rx.html) This license is already included in your Vivado license if you obtained your Webpack license from January 2020, the following step might be required if you have the older Webpack license:
+- A license for MIPI CSI controller from [MIPI CSI Controller Subsystems](https://www.xilinx.com/products/intellectual-property/ef-di-mipi-csi-rx.html)
   - Access to [Product Licensing](http://www.xilinx.com/getlicense)
   - Click "Search Now"
   - Type "MIPI CSI" in "Search:" text field
@@ -13,8 +13,8 @@ This flow generates a sample IP-block, bit-stream for ZYBO Z7-20, and BSP for th
   - Find "LogiCORE, MIPI CSI-2 Rx Controller, Evaluation License", click checkbox of that, and click "Generate Node-Locked License"
   - Fill required license and you can get an evaluation license of MIPI CSI controller.
 
-## Building flow
-Run the following script to generate hardware design. Make sure Vivado is in your path by sourcing the `settings64.sh` in Vivado's directory. 
+## Building Flow
+Run the script to generate hardware design.
 
 ``` sh
 $ cd <ROOT OF THIS REPOSITORY>/zybo/vivado/script
@@ -22,7 +22,16 @@ $ export AD_REFKIT_SAMPLE_SCRIPT_PATH=$(pwd)
 $ sh setup_bd.sh
 ```
 
-Thi script starts Vivado HLS and Vivado to generate IP-block and bit-file. The working directory is `$AD_REFKIT_SAMPLE_SCRIPT_PATH/../prj` .
-After running Vivado, the script generates `fpga.bin` in `<ROOT OF THIS REPOSITORY>/ROOT_FS/firmware`, which is a configuration file for dynamic reconfiguration of ZYBO Z7-20. Please follow the board manual on how to program the FPGA using the generated bit file.
+The script starts Vivado HLS and Vivado to generate IP-block and bit-file. The working directory is `$AD_REFKIT_SAMPLE_SCRIPT_PATH/../prj` .
+After running Vivado, the script generates `fpga.bin` in `<ROOT OF THIS REPOSITORY>/ROOT_FS/firmware`, which is a configuration file for dynamic reconfiguration of ZYBO Z7-20.
 The script also generates BSP for software development in `<ROOT OF THIS REPOSITORY>/zybo/ROOT_FS/zynq_bsp/`.
 
+## Building Flow with Vivado 2020.1
+Starting from Vivado 2020.1, the Xilinx XSDK is replaced with a new development platform called Vitis. The Vitis API is different compared to the old XSDK. Also, the MIPI CSI IP which is used in this project is updated. Therefore, we provide a different build script for Vivado 2020.1 platform. Once the project is initiated for Vivado 2020.1, it will not be able to be opened in older Vivado version.
+
+
+``` sh
+$ cd <ROOT OF THIS REPOSITORY>/zybo/vivado/script
+$ export AD_REFKIT_SAMPLE_SCRIPT_PATH=$(pwd)
+$ sh setup_bd_20201.sh
+```

--- a/docs/sec2/index.md
+++ b/docs/sec2/index.md
@@ -5,7 +5,7 @@ This flow generates a sample IP-block, bit-stream for ZYBO Z7-20, and BSP for th
 - Host PC, with Ubuntu 18.04
 - Vivado 2019.1
 - [Digilent board files](https://github.com/Digilent/vivado-boards)
-- A license for MIPI CSI controller from [MIPI CSI Controller Subsystems](https://www.xilinx.com/products/intellectual-property/ef-di-mipi-csi-rx.html)
+- A license for MIPI CSI controller from [MIPI CSI Controller Subsystems](https://www.xilinx.com/products/intellectual-property/ef-di-mipi-csi-rx.html) This license is already included in your Vivado license if you obtained your Webpack license from January 2020, the following step might be required if you have the older Webpack license:
   - Access to [Product Licensing](http://www.xilinx.com/getlicense)
   - Click "Search Now"
   - Type "MIPI CSI" in "Search:" text field

--- a/docs/sec2/index.md
+++ b/docs/sec2/index.md
@@ -2,7 +2,7 @@
 This flow generates a sample IP-block, bit-stream for ZYBO Z7-20, and BSP for the generated HW.
 
 ## Requirements
-- Host PC, installed Ubuntu 18.04
+- Host PC, with Ubuntu 18.04
 - Vivado 2019.1
 - [Digilent board files](https://github.com/Digilent/vivado-boards)
 - A license for MIPI CSI controller from [MIPI CSI Controller Subsystems](https://www.xilinx.com/products/intellectual-property/ef-di-mipi-csi-rx.html)
@@ -14,7 +14,7 @@ This flow generates a sample IP-block, bit-stream for ZYBO Z7-20, and BSP for th
   - Fill required license and you can get an evaluation license of MIPI CSI controller.
 
 ## Building flow
-Run a script to generate hardware design.
+Run the following script to generate hardware design. Make sure Vivado is in your path by sourcing the `settings64.sh` in Vivado's directory. 
 
 ``` sh
 $ cd <ROOT OF THIS REPOSITORY>/zybo/vivado/script
@@ -22,7 +22,7 @@ $ export AD_REFKIT_SAMPLE_SCRIPT_PATH=$(pwd)
 $ sh setup_bd.sh
 ```
 
-The script starts Vivado HLS and Vivado to generate IP-block and bit-file. The working directory is `$AD_REFKIT_SAMPLE_SCRIPT_PATH/../prj` .
-After running Vivado, the script generates `fpga.bin` in `<ROOT OF THIS REPOSITORY>/ROOT_FS/firmware`, which is a configuration file for dynamic reconfiguration of ZYBO Z7-20.
+Thi script starts Vivado HLS and Vivado to generate IP-block and bit-file. The working directory is `$AD_REFKIT_SAMPLE_SCRIPT_PATH/../prj` .
+After running Vivado, the script generates `fpga.bin` in `<ROOT OF THIS REPOSITORY>/ROOT_FS/firmware`, which is a configuration file for dynamic reconfiguration of ZYBO Z7-20. Please follow the board manual on how to program the FPGA using the generated bit file.
 The script also generates BSP for software development in `<ROOT OF THIS REPOSITORY>/zybo/ROOT_FS/zynq_bsp/`.
 

--- a/docs/sec3/index.md
+++ b/docs/sec3/index.md
@@ -24,3 +24,9 @@ $ cp arch/arm/boot/uImage <ROOT OF THIS REPOSITORY>/zybo/BOOT_FS
 $ cp arch/arm/boot/dts/zynq-zybo-z7.dtb <ROOT OF THIS REPOSITORY>/zybo/BOOT_FS
 $ cp ../linux-*.deb <ROOT OF THIS REPOSITORY>/zybo/ROOT_FS/package
 ```
+A shell script to automate this process is provided for your convenience. Install the requirements then run the provided script. Make sure `AD_REFKIT_SAMPLE_SCRIPT_PATH` is set as instructed in the previous step.
+``` sh
+$ sudo apt install build-essential ccache bc bison flex ncurses-dev git u-boot-tools gcc-arm*
+$ sh build_linux.sh
+```
+ 

--- a/docs/sec3/index.md
+++ b/docs/sec3/index.md
@@ -1,13 +1,13 @@
 ## Building Linux
-It is able to skip this flow. The generated files by this flow are available in this repository.
-The files are the followings.
+This step is optional. The generated files by this flow are available in this repository.
+The required files are as follows:
 - [uImage](../../zybo/BOOT_FS/uImage)
 - [zynq-zybo-z7.dtb](../../zybo/BOOT_FS/zynq-zybo-z7.dtb)
 - [Debian packages (headers, image, libc)](../../zybo/ROOT_FS/package/)
 
-If you want to build Linux on your computer, please run the followings.
+If you want to build the Linux kernel on your computer, please run the followings:
 ``` sh
-$ apt install build-essential ccache bc bison flex ncurses-dev git u-boot-tools
+$ apt install build-essential ccache bc bison flex ncurses-dev git u-boot-tools gcc-arm*
 $ git clone --depth 1 -b xilinx-v2019.1 https://github.com/Xilinx/linux-xlnx.git linux-xlnx-v2019.1-zybo-z7 && cd linux-xlnx-v2019.1-zybo-z7
 $ git checkout -b linux-xlnx-v2019.1-zybo-z7 refs/tags/xilinx-v2019.1
 $ sed -i -e 's|bootargs = ""|bootargs = "console=ttyPS0,115200 root=/dev/mmcblk0p2 rw earlyprintk rootfstype=ext4 rootwait devtmpfs.mount=1 uio_pdrv_genirq.of_id=generic-uio earlycon"|g' arch/arm/boot/dts/zynq-zybo-z7.dts

--- a/docs/sec4/index.md
+++ b/docs/sec4/index.md
@@ -16,17 +16,19 @@ $ sudo gparted
 - 1st partition : fat16, about 64-128MiB
 - 2nd partition : ext4, all of rest
 
+Pay attention to your MicroSD location (`/dev/sdX`) with X denoting your MicroSD location. Be careful not to use another drive.
+
 ### 2. Prepare rootfs
 The next step is building the debian root filesystem for the FPGA board. There are two ways to achieve this: building the entire filesystem on host PC, then copy the resulting files to the MicroSD, or mount the MicroSD and build the filesystem directly on the MicroSD. The latter is considerably slower than the former.
 
-To achieve this, we will create a new chroot-ed directory for the debootstrap to work, then set the architecture of the filesystem to ARM. QEMU will be used to run the chroot-ed ARM filesystem on your PC. As the debootstrap completes its task, we will then install and configure the system as well as compiling OpenCV. The OpenCV compilation might take few hours depending on your PC.
+To achieve this, we will create a new chroot-ed directory for the debootstrap to work, then set the architecture of the filesystem to ARM. QEMU will be used to run the chroot-ed ARM filesystem on your PC. As the debootstrap completes its task, we will then install and configure the system as well as compiling OpenCV. The OpenCV compilation might take few hours depending on your PC. A script to streamline the building proces is also prepared.
 
 
 #### Building rootfs directly on the MicroSD
 
 ```
 # install Ubuntu 18.04 LTS and neessary packages
-$ sudo mount /dev/<YOUR SD #2> /mnt # ex. /dev/sdd2
+$ sudo mount /dev/<YOUR SD #2 partition> /mnt # ex. /dev/sdd2
 $ sudo debootstrap --foreign --arch armhf bionic /mnt http://ports.ubuntu.com/
 $ sudo apt install qemu-user-static
 $ sudo cp /usr/bin/qemu-arm-static /mnt/usr/bin/
@@ -155,13 +157,30 @@ root@ubuntu:# cd /root
 root@ubuntu:# git clone https://github.com/lwfinger/rtl8188eu.git
 root@ubuntu:# exit
 I have no name!@ubuntu:# exit
-$ sudo mount /dev/<YOUR SD #2> /mnt # ex. /dev/sdd2
+$ sudo mount /dev/<YOUR SD #2 partition> /mnt # ex. /dev/sdd2
 $ cd $WORKDIR
 $ sudo tar cpvf - * | sudo tar xpvf - -C /mnt
 $ sync; sync; sync
 $ sudo umount /mnt
 $ sudo eject /dev/<YOUR SD> /mnt # ex. /dev/sdd
 ```
+
+
+#### Building rootfs on your host PC with the script and  copy the files to MicroSD
+Run the following script then copy the generated files to the MicroSD card. The script will generate the MicroSD image on the top most directory of this repository.
+
+```
+$ cd <ROOT OF THIS REPOSITORY>/zybo/vivado/script
+$ export AD_REFKIT_SAMPLE_SCRIPT_PATH=$(pwd)
+$ sh build_rootfs.sh
+$ sudo mount /dev/<YOUR SD #2 partition> /mnt # ex. /dev/sdd2
+$ cd $WORKDIR
+$ sudo tar cpvf - * | sudo tar xpvf - -C /mnt
+$ sync; sync; sync
+$ sudo umount /mnt
+$ sudo eject /dev/<YOUR SD> /mnt # ex. /dev/sdd
+```
+
 
 ### 3. Prepare bootfs
 Copy the following five files into bootfs i.e. 1st partition.

--- a/docs/sec4/index.md
+++ b/docs/sec4/index.md
@@ -19,7 +19,7 @@ $ sudo gparted
 Pay attention to your MicroSD location (`/dev/sdX`) with X denoting your MicroSD location. Be careful not to use another drive.
 
 ### 2. Prepare rootfs
-The next step is building the debian root filesystem for the FPGA board. There are two ways to achieve this: building the entire filesystem on host PC, then copy the resulting files to the MicroSD, or mount the MicroSD and build the filesystem directly on the MicroSD. The latter is considerably slower than the former. As a third option, a script to streamline the building proces is also prepared for your convenience.
+The next step is building the debian root filesystem for the FPGA board. There are two ways to achieve this: building the entire filesystem on host PC, then copy the resulting files to the MicroSD, or mount the MicroSD and build the filesystem directly on the MicroSD. The latter is considerably slower than the former. As a third option, we can use the provided script to streamline the building process for your convenience.
 
 To achieve this, we will create a new chroot-ed directory for the debootstrap to work, then set the architecture of the filesystem to ARM. QEMU will be used to run the chroot-ed ARM filesystem on your PC. As the debootstrap completes its task, we will then install and configure the system as well as compiling OpenCV. The OpenCV compilation might take few hours depending on your PC. 
 

--- a/docs/sec4/index.md
+++ b/docs/sec4/index.md
@@ -19,9 +19,9 @@ $ sudo gparted
 Pay attention to your MicroSD location (`/dev/sdX`) with X denoting your MicroSD location. Be careful not to use another drive.
 
 ### 2. Prepare rootfs
-The next step is building the debian root filesystem for the FPGA board. There are two ways to achieve this: building the entire filesystem on host PC, then copy the resulting files to the MicroSD, or mount the MicroSD and build the filesystem directly on the MicroSD. The latter is considerably slower than the former.
+The next step is building the debian root filesystem for the FPGA board. There are two ways to achieve this: building the entire filesystem on host PC, then copy the resulting files to the MicroSD, or mount the MicroSD and build the filesystem directly on the MicroSD. The latter is considerably slower than the former. As a third option, a script to streamline the building proces is also prepared for your convenience.
 
-To achieve this, we will create a new chroot-ed directory for the debootstrap to work, then set the architecture of the filesystem to ARM. QEMU will be used to run the chroot-ed ARM filesystem on your PC. As the debootstrap completes its task, we will then install and configure the system as well as compiling OpenCV. The OpenCV compilation might take few hours depending on your PC. A script to streamline the building proces is also prepared.
+To achieve this, we will create a new chroot-ed directory for the debootstrap to work, then set the architecture of the filesystem to ARM. QEMU will be used to run the chroot-ed ARM filesystem on your PC. As the debootstrap completes its task, we will then install and configure the system as well as compiling OpenCV. The OpenCV compilation might take few hours depending on your PC. 
 
 
 #### Building rootfs directly on the MicroSD

--- a/docs/sec4/index.md
+++ b/docs/sec4/index.md
@@ -1,13 +1,13 @@
 ## Prepare microSD
-### 1. Format microSD
+### 1. Format the MicroSD Card
 Make partition with GParted. \
-If you have not installed GParted yet, install it.
+If you do not have GParted installed yet, please install it. Also, debootstrap is required to create a basic debian filesystem on the MicroSD.
 
 ``` sh
 $ sudo apt install gparted debootstrap 
 ```
 
-Run GParted, and then make partitions on microSD as the followigns.
+Run GParted, and then make two partitions on the MicroSD as follows:
 
 ``` sh
 $ sudo gparted
@@ -17,9 +17,12 @@ $ sudo gparted
 - 2nd partition : ext4, all of rest
 
 ### 2. Prepare rootfs
-Run the following commands on MicroSD or your host storage. Building on MicroSD requires longer time.
+The next step is building the debian root filesystem for the FPGA board. There are two ways to achieve this: building the entire filesystem on host PC, then copy the resulting files to the MicroSD, or mount the MicroSD and build the filesystem directly on the MicroSD. The latter is considerably slower than the former.
 
-#### Building rootfs on MicroSD
+To achieve this, we will create a new chroot-ed directory for the debootstrap to work, then set the architecture of the filesystem to ARM. QEMU will be used to run the chroot-ed ARM filesystem on your PC. As the debootstrap completes its task, we will then install and configure the system as well as compiling OpenCV. The OpenCV compilation might take few hours depending on your PC.
+
+
+#### Building rootfs directly on the MicroSD
 
 ```
 # install Ubuntu 18.04 LTS and neessary packages
@@ -88,7 +91,7 @@ $ sudo umount /mnt
 $ sudo eject /dev/<YOUR SD> /mnt # ex. /dev/sdd
 ```
 
-#### Building rootfs on your host and copy them to MicroSD
+#### Building rootfs on your host PC and copy the files to MicroSD
 
 ```
 $ mkdir <WORKING DIRECTORY>; cd <WORKING DIRECTORY> # ~/microsd
@@ -169,7 +172,7 @@ Copy the following five files into bootfs i.e. 1st partition.
 - [uramdisk.image.gz](../../zybo/BOOT_FS/uramdisk.image.gz)
 - [zynq-zybo-z7.dtb](../../zybo/BOOT_FS/zynq-zybo-z7.dtb)
 
-It is able to use the files in `zybo/BOOT_FS` as they are.
+We can use files generated in [Building Linux](../sec3/index.md) or use files in `zybo/BOOT_FS` as they are.
 
 #### 3.1 BOOT.bin
 `BOOT.bin` is generated from the follow three files.

--- a/zybo/vivado/script/build_linux.sh
+++ b/zybo/vivado/script/build_linux.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# sudo apt install build-essential ccache bc bison flex ncurses-dev git u-boot-tools gcc-arm*
+
+
+if [ -n "$AD_REFKIT_SAMPLE_SCRIPT_PATH" ];
+then
+    cd $AD_REFKIT_SAMPLE_SCRIPT_PATH/../../..
+    AD_REFKIT_ROOT=$(pwd)
+	mkdir linux && cd linux
+	git clone --depth 1 -b xilinx-v2019.1 https://github.com/Xilinx/linux-xlnx.git linux-xlnx-v2019.1-zybo-z7 && cd linux-xlnx-v2019.1-zybo-z7
+	git checkout -b linux-xlnx-v2019.1-zybo-z7 refs/tags/xilinx-v2019.1
+	sed -i -e 's|bootargs = ""|bootargs = "console=ttyPS0,115200 root=/dev/mmcblk0p2 rw earlyprintk rootfstype=ext4 rootwait devtmpfs.mount=1 uio_pdrv_genirq.of_id=generic-uio earlycon"|g' arch/arm/boot/dts/zynq-zybo-z7.dts
+	patch -p1 < $AD_REFKIT_ROOT/assets/patch/linux-xlnx-v2019.1-zybo-z7-builddeb.diff
+	make xilinx_zynq_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
+	patch -p0 < $AD_REFKIT_ROOT/assets/patch/dot.config.patch
+	ccache make -j$(nproc) deb-pkg ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- DTC_FLAGS=--symbols
+	make uImage ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- UIMAGE_LOADADDR=0x8000
+	cp arch/arm/boot/uImage $AD_REFKIT_ROOT/zybo/BOOT_FS
+	cp arch/arm/boot/dts/zynq-zybo-z7.dtb $AD_REFKIT_ROOT/zybo/BOOT_FS
+	cp ../linux-*.deb $AD_REFKIT_ROOT/zybo/ROOT_FS/package
+    
+else
+    echo "Please set environment value like this."
+    echo "$ cd <ROOT OF THIS REPOSITORY>/zybo/vivado/script"
+    echo "$ export AD_REFKIT_SAMPLE_SCRIPT_PATH=\$(pwd)"
+fi

--- a/zybo/vivado/script/build_rootfs.sh
+++ b/zybo/vivado/script/build_rootfs.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+#sudo apt install qemu-user-static debootstrap
+
+
+if [ -n "$AD_REFKIT_SAMPLE_SCRIPT_PATH" ];
+then
+    cd $AD_REFKIT_SAMPLE_SCRIPT_PATH/../../..
+
+
+	mkdir microsd; cd microsd
+	export WORKDIR=$(pwd)
+	sudo qemu-debootstrap --foreign --arch armhf bionic $WORKDIR http://ports.ubuntu.com/ 
+	sudo cp -r ../zybo/ROOT_FS/* root/
+	sudo cp /usr/bin/qemu-arm-static $WORKDIR/usr/bin/
+	sudo chroot $WORKDIR /bin/bash <<"EOT"
+	./debootstrap/debootstrap --second-stage
+	apt install -y software-properties-common
+	add-apt-repository universe && apt update
+	export LANGUAGE=en_US.UTF-8
+	export LANG=en_US.UTF-8
+	export LC_ALL=en_US.UTF-8
+	apt install -y locales ssh chrony libusb-1.0-0-dev ntpdate bc
+	locale-gen en_US.UTF-8
+	adduser --disabled-password --gecos "" user
+	apt install -y git
+	git clone -b v1.4.7 https://git.kernel.org/pub/scm/utils/dtc/dtc.git dtc && cd dtc
+	apt install -y build-essential flex bison
+	make && make HOME=/usr install-bin
+	cd .. && rm -rf dtc
+	sed -i -e 's/#PasswordAuthentication/PasswordAuthentication/g' /etc/ssh/sshd_config
+	sed -i -e 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config
+	sed -i -e 's/AcceptEnv/#AcceptEnv/g' /etc/ssh/sshd_config
+	echo 'server ntp1.jst.mfeed.ad.jp iburst' >> /etc/ntp.conf 
+	systemctl enable chrony
+	echo "[Match]
+Name=eth0
+[Network]
+DHCP=ipv4" >> /etc/systemd/network/eth0.network
+	systemctl enable systemd-networkd
+	apt install -y \
+              build-essential cmake ccache git pkg-config libgtk-3-dev \
+              libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
+              libxvidcore-dev libx264-dev libjpeg-dev libpng-dev libtiff-dev \
+              gfortran openexr libatlas-base-dev python3-dev python3-numpy \
+              libtbb2 libtbb-dev libdc1394-22-dev
+	mkdir opencv_build && cd opencv_build
+	git clone --depth 1 https://github.com/opencv/opencv.git
+	git clone --depth 1 https://github.com/opencv/opencv_contrib.git
+	export OPENCV_BUILD_PATH=$(pwd)
+	cd opencv && mkdir build && cd build
+	cmake -D CMAKE_BUILD_TYPE=RELEASE \
+               -D CMAKE_INSTALL_PREFIX=/usr/local \
+               -D INSTALL_C_EXAMPLES=ON \
+               -D INSTALL_PYTHON_EXAMPLES=ON \
+               -D OPENCV_GENERATE_PKGCONFIG=ON \
+               -D OPENCV_EXTRA_MODULES_PATH=$(printenv OPENCV_BUILD_PATH)/opencv_contrib/modules \
+               -D BUILD_EXAMPLES=ON ..
+	ccache make -j$(nproc)
+	make install -j$(nproc)
+	pkg-config --modversion opencv4
+	cd ../../../ && rm -rf opencv_build
+	apt install -y wireless-tools rfkill wpasupplicant linux-firmware libssl-dev usbutils
+	cd /root
+	git clone https://github.com/lwfinger/rtl8188eu.git
+	exit
+EOT
+ 
+else
+    echo "Please set environment value like this."
+    echo "$ cd <ROOT OF THIS REPOSITORY>/zybo/vivado/script"
+    echo "$ export AD_REFKIT_SAMPLE_SCRIPT_PATH=\$(pwd)"
+fi

--- a/zybo/vivado/script/create_bsp_vitis.tcl
+++ b/zybo/vivado/script/create_bsp_vitis.tcl
@@ -1,0 +1,6 @@
+setws ../prj/ad_refkit/ad_refkit.sdk
+platform create -name {ad_refkit} -hw {../prj/ad_refkit/zybo_top.xsa} -proc {ps7_cortexa9_0} -os {standalone} -out {../prj/ad_refkit/ad_refkit.sdk};platform write
+# platform read {../prj/ad_refkit/ad_refkit.sdk/ad_refkit/platform.spr}
+platform active {ad_refkit}
+domain active {standalone_domain}
+platform generate

--- a/zybo/vivado/script/create_prj.tcl
+++ b/zybo/vivado/script/create_prj.tcl
@@ -245,7 +245,7 @@ proc cr_bd_design_1 { parentCell } {
   xilinx.com:ip:axi_gpio:2.0\
   Digilent:user:AXI_BayerToRGB:1.0\
   Digilent:user:AXI_GammaCorrection:1.0\
-  xilinx.com:ip:mipi_csi2_rx_subsystem:4.0\
+  xilinx.com:ip:mipi_csi2_rx_subsystem:5.0\
   xilinx.com:ip:axi_vdma:6.3\
   xilinx.com:hls:preimproc:1.0\
   xilinx.com:ip:smartconnect:1.0\
@@ -1268,7 +1268,7 @@ proc create_hier_cell_cam_interface { parentCell nameHier } {
   set AXI_GammaCorrection_0 [ create_bd_cell -type ip -vlnv Digilent:user:AXI_GammaCorrection:1.0 AXI_GammaCorrection_0 ]
 
   # Create instance: mipi_csi2_rx_subsyst_0, and set properties
-  set mipi_csi2_rx_subsyst_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:mipi_csi2_rx_subsystem:4.0 mipi_csi2_rx_subsyst_0 ]
+  set mipi_csi2_rx_subsyst_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:mipi_csi2_rx_subsystem:5.0 mipi_csi2_rx_subsyst_0 ]
   set_property -dict [ list \
    CONFIG.CMN_NUM_LANES {2} \
    CONFIG.CMN_NUM_PIXELS {4} \

--- a/zybo/vivado/script/create_prj.tcl
+++ b/zybo/vivado/script/create_prj.tcl
@@ -245,7 +245,7 @@ proc cr_bd_design_1 { parentCell } {
   xilinx.com:ip:axi_gpio:2.0\
   Digilent:user:AXI_BayerToRGB:1.0\
   Digilent:user:AXI_GammaCorrection:1.0\
-  xilinx.com:ip:mipi_csi2_rx_subsystem:5.0\
+  xilinx.com:ip:mipi_csi2_rx_subsystem:4.0\
   xilinx.com:ip:axi_vdma:6.3\
   xilinx.com:hls:preimproc:1.0\
   xilinx.com:ip:smartconnect:1.0\
@@ -1268,7 +1268,7 @@ proc create_hier_cell_cam_interface { parentCell nameHier } {
   set AXI_GammaCorrection_0 [ create_bd_cell -type ip -vlnv Digilent:user:AXI_GammaCorrection:1.0 AXI_GammaCorrection_0 ]
 
   # Create instance: mipi_csi2_rx_subsyst_0, and set properties
-  set mipi_csi2_rx_subsyst_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:mipi_csi2_rx_subsystem:5.0 mipi_csi2_rx_subsyst_0 ]
+  set mipi_csi2_rx_subsyst_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:mipi_csi2_rx_subsystem:4.0 mipi_csi2_rx_subsyst_0 ]
   set_property -dict [ list \
    CONFIG.CMN_NUM_LANES {2} \
    CONFIG.CMN_NUM_PIXELS {4} \

--- a/zybo/vivado/script/export_xsa.tcl
+++ b/zybo/vivado/script/export_xsa.tcl
@@ -1,5 +1,5 @@
 #open project
-open_project /home/boma/migrate/ad-refkit/zybo/vivado/prj/ad_refkit/ad_refkit.xpr
+open_project ../prj/ad_refkit/ad_refkit.xpr
 update_compile_order -fileset sources_1
 
 #write xsa files for vitis

--- a/zybo/vivado/script/export_xsa.tcl
+++ b/zybo/vivado/script/export_xsa.tcl
@@ -1,0 +1,8 @@
+#open project
+open_project /home/boma/migrate/ad-refkit/zybo/vivado/prj/ad_refkit/ad_refkit.xpr
+update_compile_order -fileset sources_1
+
+#write xsa files for vitis
+set_property pfm_name {} [get_files -all {../prj/ad_refkit/ad_refkit.srcs/sources_1/bd/design_1/design_1.bd}]
+write_hw_platform -fixed -force -file ../prj/ad_refkit/zybo_top.xsa
+

--- a/zybo/vivado/script/setup_bd_20201.sh
+++ b/zybo/vivado/script/setup_bd_20201.sh
@@ -8,8 +8,8 @@ then
     rm -rf ad_refkit
     rm -rf preimproc_prj
     env SWT_GTK3=0 vivado_hls $AD_REFKIT_SAMPLE_SCRIPT_PATH/generate_hls_ip.tcl
-    patch $AD_REFKIT_SAMPLE_SCRIPT_PATH/create_prj.tcl $AD_REFKIT_SAMPLE_SCRIPT_PATH/update20201.patch
-    env SWT_GTK3=0 vivado -mode batch -source $AD_REFKIT_SAMPLE_SCRIPT_PATH/create_prj.tcl
+    patch $AD_REFKIT_SAMPLE_SCRIPT_PATH/create_prj.tcl $AD_REFKIT_SAMPLE_SCRIPT_PATH/update20201.patch -o $AD_REFKIT_SAMPLE_SCRIPT_PATH/create_prj_20201.tcl
+    env SWT_GTK3=0 vivado -mode batch -source $AD_REFKIT_SAMPLE_SCRIPT_PATH/create_prj_20201.tcl
     env SWT_GTK3=0 vivado -mode batch -source $AD_REFKIT_SAMPLE_SCRIPT_PATH/export_xsa.tcl
     cd $AD_REFKIT_SAMPLE_SCRIPT_PATH
     chmod u+x fpga-bit2bin.py

--- a/zybo/vivado/script/setup_bd_20201.sh
+++ b/zybo/vivado/script/setup_bd_20201.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+if [ -n "$AD_REFKIT_SAMPLE_SCRIPT_PATH" ];
+then
+    cd $AD_REFKIT_SAMPLE_SCRIPT_PATH/../prj
+    rm -f vivado.jou
+    rm -f vivado.log
+    rm -f vivado_hls.log
+    rm -rf ad_refkit
+    rm -rf preimproc_prj
+    env SWT_GTK3=0 vivado_hls $AD_REFKIT_SAMPLE_SCRIPT_PATH/generate_hls_ip.tcl
+    patch $AD_REFKIT_SAMPLE_SCRIPT_PATH/create_prj.tcl $AD_REFKIT_SAMPLE_SCRIPT_PATH/update20201.patch
+    env SWT_GTK3=0 vivado -mode batch -source $AD_REFKIT_SAMPLE_SCRIPT_PATH/create_prj.tcl
+    env SWT_GTK3=0 vivado -mode batch -source $AD_REFKIT_SAMPLE_SCRIPT_PATH/export_xsa.tcl
+    cd $AD_REFKIT_SAMPLE_SCRIPT_PATH
+    chmod u+x fpga-bit2bin.py
+    sh create_bitstream_bin.sh
+    xsct $AD_REFKIT_SAMPLE_SCRIPT_PATH/create_bsp_vitis.tcl
+    cp -R $AD_REFKIT_SAMPLE_SCRIPT_PATH/../prj/ad_refkit/ad_refkit.sdk/ad_refkit/ps7_cortexa9_0/standalone_domain/bsp/ps7_cortexa9_0 \
+          $AD_REFKIT_SAMPLE_SCRIPT_PATH/../../ROOT_FS/zynq_bsp/
+else
+    echo "Please set environment value like this."
+    echo "$ cd <ROOT OF THIS REPOSITORY>/zybo/vivado/script"
+    echo "$ export AD_REFKIT_SAMPLE_SCRIPT_PATH=\$(pwd)"
+fi

--- a/zybo/vivado/script/update20201.patch
+++ b/zybo/vivado/script/update20201.patch
@@ -1,0 +1,20 @@
+--- create_prj.tcl	2020-10-03 20:56:52.332383000 +0900
++++ create_prj.tcl	2020-10-06 22:13:15.859665841 +0900
+@@ -245,7 +245,7 @@
+   xilinx.com:ip:axi_gpio:2.0\
+   Digilent:user:AXI_BayerToRGB:1.0\
+   Digilent:user:AXI_GammaCorrection:1.0\
+-  xilinx.com:ip:mipi_csi2_rx_subsystem:4.0\
++  xilinx.com:ip:mipi_csi2_rx_subsystem:5.0\
+   xilinx.com:ip:axi_vdma:6.3\
+   xilinx.com:hls:preimproc:1.0\
+   xilinx.com:ip:smartconnect:1.0\
+@@ -1268,7 +1268,7 @@
+   set AXI_GammaCorrection_0 [ create_bd_cell -type ip -vlnv Digilent:user:AXI_GammaCorrection:1.0 AXI_GammaCorrection_0 ]
+ 
+   # Create instance: mipi_csi2_rx_subsyst_0, and set properties
+-  set mipi_csi2_rx_subsyst_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:mipi_csi2_rx_subsystem:4.0 mipi_csi2_rx_subsyst_0 ]
++  set mipi_csi2_rx_subsyst_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:mipi_csi2_rx_subsystem:5.0 mipi_csi2_rx_subsyst_0 ]
+   set_property -dict [ list \
+    CONFIG.CMN_NUM_LANES {2} \
+    CONFIG.CMN_NUM_PIXELS {4} \


### PR DESCRIPTION
A new hardware build script for Vivado 2020.1 and Vitis is added (the old build script still exist for Vivado 2019.1 users). It offers alternative for user with newer Vivado version which no longer includes Xilinx XSDK. See Sec 2 of the documentation for details.